### PR TITLE
Fixed deprecation when modifiers are at the end of a 're' expression

### DIFF
--- a/gitignore_parser.py
+++ b/gitignore_parser.py
@@ -166,5 +166,6 @@ def fnmatch_pathname_to_regex(pattern):
 				res.append('[{}]'.format(stuff))
 		else:
 			res.append(re.escape(c))
-	res.append('\Z(?ms)')
+	res.insert(0, '(?ms)')
+	res.append('\Z')
 	return ''.join(res)


### PR DESCRIPTION
The following warning was being produced:

```
gitignore_parser.py:118: DeprecationWarning: Flags not at the start of the expression 'XYZ' (truncated) if re.search(self.regex, rel_path):
```

We probably could use the 3rd argument of `re.search` but that looks like more work than I have time for at the moment.