### PR TITLE
Fixed 1 issue of type: PYTHON_E251 throughout 1 file in repo.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,7 @@ setup(
     name='gitignore_parser',
     version='0.0.4',
     description=description,
-    long_description=
-        description + '\n\nhttps://github.com/mherrmann/gitignore_parser',
+    long_description=        description + '\n\nhttps://github.com/mherrmann/gitignore_parser',
     author='Michael Herrmann',
     author_email='michael+removethisifyouarehuman@herrmann.io',
     url='https://github.com/mherrmann/gitignore_parser',


### PR DESCRIPTION
PYTHON_E251: 'unexpected spaces around keyword / parameter equals'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.