### PR TITLE
Fixed 3 issues of type: PYTHON_W293 throughout 1 file in repo.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,11 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
-    
+
         'License :: OSI Approved :: MIT License',
-    
+
         'Operating System :: OS Independent',
-    
+
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',


### PR DESCRIPTION
PYTHON_W293: 'Remove trailing whitespace on blank line.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.