### PR TITLE
Windows bug fix and compatibility

### DIFF
--- a/gitignore_parser.py
+++ b/gitignore_parser.py
@@ -1,6 +1,6 @@
 import collections
 import os
-import regex as re
+import re
 
 from os.path import dirname, abspath
 from pathlib import Path
@@ -173,5 +173,5 @@ def fnmatch_pathname_to_regex(pattern):
 		else:
 			res.append(re.escape(c))
 	res.insert(0, '(?ms)')
-	res.append('\\Z')
+	res.append('$')
 	return ''.join(res)

--- a/gitignore_parser.py
+++ b/gitignore_parser.py
@@ -129,14 +129,14 @@ def fnmatch_pathname_to_regex(pattern):
 	res = []
 	while i < n:
 		c = pattern[i]
-		i = i + 1
+		i += 1
 		if c == '*':
 			try:
 				if pattern[i] == '*':
-					i = i + 1
+					i += 1
 					res.append('.*')
 					if pattern[i] == '/':
-						i = i + 1
+						i += 1
 						res.append(''.join([os.sep, '?']))
 				else:
 					res.append(''.join([nonsep, '*']))
@@ -149,23 +149,23 @@ def fnmatch_pathname_to_regex(pattern):
 		elif c == '[':
 			j = i
 			if j < n and pattern[j] == '!':
-				j = j + 1
+				j += 1
 			if j < n and pattern[j] == ']':
-				j = j + 1
+				j += 1
 			while j < n and pattern[j] != ']':
-				j = j+1
+				j += 1
 			if j >= n:
 				res.append('\\[')
 			else:
 				stuff = pattern[i:j].replace('\\', '\\\\')
-				i = j+1
+				i = j + 1
 				if stuff[0] == '!':
-					stuff = ''.join('^', stuff[1:])
+					stuff = ''.join(['^', stuff[1:]])
 				elif stuff[0] == '^':
 					stuff = ''.join('\\' + stuff)
 				res.append('[{}]'.format(stuff))
 		else:
 			res.append(re.escape(c))
 	res.insert(0, '(?ms)')
-	res.append('\Z')
+	res.append('\\Z')
 	return ''.join(res)

--- a/gitignore_parser.py
+++ b/gitignore_parser.py
@@ -125,7 +125,13 @@ def fnmatch_pathname_to_regex(pattern):
 	the path seperator will not match shell-style '*' and '.' wildcards.
 	"""
 	i, n = 0, len(pattern)
-	nonsep = ''.join(['[^', os.sep, ']'])
+	
+	seps = [re.escape(os.sep)]
+	if os.altsep is not None:
+		seps.append(re.escape(os.altsep))
+	seps_group = '[' + '|'.join(seps) + ']'
+	nonsep = r'[^{}]'.format('|'.join(seps))
+
 	res = []
 	while i < n:
 		c = pattern[i]
@@ -137,7 +143,7 @@ def fnmatch_pathname_to_regex(pattern):
 					res.append('.*')
 					if pattern[i] == '/':
 						i += 1
-						res.append(''.join([os.sep, '?']))
+						res.append(''.join([seps_group, '?']))
 				else:
 					res.append(''.join([nonsep, '*']))
 			except IndexError:
@@ -145,7 +151,7 @@ def fnmatch_pathname_to_regex(pattern):
 		elif c == '?':
 			res.append(nonsep)
 		elif c == '/':
-			res.append(os.sep)
+			res.append(seps_group)
 		elif c == '[':
 			j = i
 			if j < n and pattern[j] == '!':

--- a/gitignore_parser.py
+++ b/gitignore_parser.py
@@ -1,6 +1,6 @@
 import collections
 import os
-import re
+import regex as re
 
 from os.path import dirname, abspath
 from pathlib import Path

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
     author_email='michael+removethisifyouarehuman@herrmann.io',
     url='https://github.com/mherrmann/gitignore_parser',
     py_modules=['gitignore_parser'],
-    install_requires=['regex'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     author_email='michael+removethisifyouarehuman@herrmann.io',
     url='https://github.com/mherrmann/gitignore_parser',
     py_modules=['gitignore_parser'],
+    install_requires=['regex'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Fix for fatal error appearing on Windows when you try to use current version of module - re throws an error about unterminated characters because of insufficient escaping (`os.sep` is indeed escaped for python purposes, but on Windows re needs double escaping). Furthermore, re doesn't seem to operate on a few expressions used in current version (as they are part of extended perl-like set, e.g. '\Z') so I changed it to third-party regex - it's fully backward-compatible. In addition to error fix, now the module is more windows-compatible as it supports os.altpath.