### PR TITLE
Add pathlib as required (for python2 usage)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ description = 'A spec-compliant gitignore parser for Python 3.5+'
 setup(
     name='gitignore_parser',
     version='0.0.5',
+    install_requires=['pathlib'],
     description=description,
     long_description=
         description + '\n\nhttps://github.com/mherrmann/gitignore_parser',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ description = 'A spec-compliant gitignore parser for Python 3.5+'
 setup(
     name='gitignore_parser',
     version='0.0.5',
-    install_requires=['pathlib'],
+    install_requires=["pathlib; python_version < '3.0'"],
     description=description,
     long_description=
         description + '\n\nhttps://github.com/mherrmann/gitignore_parser',


### PR DESCRIPTION
Even if designed for python3, gitignore_parser perfectly works with python2, except that pathlib is not provided by default with python2.
(Yes, I know, python2 is dead...)