### PR TITLE
Fix incorrect anchoring at start of string

### DIFF
--- a/gitignore_parser.py
+++ b/gitignore_parser.py
@@ -172,6 +172,6 @@ def fnmatch_pathname_to_regex(pattern):
 				res.append('[{}]'.format(stuff))
 		else:
 			res.append(re.escape(c))
-	res.insert(0, '(?ms)')
+	res.insert(0, '^(?ms)')
 	res.append('$')
 	return ''.join(res)


### PR DESCRIPTION
re.search will find substrings unless we anchor. I *think* all gitignore rules should be anchored but I'm not 100% sure (hard to tell without test coverage).
Another solution could be to replace `.search` with `.match` but I don't see any obvious difference in behavior.

Fixes #10