### PR TITLE
Fix negation rules and ** parsing.

### DIFF
--- a/gitignore_parser.py
+++ b/gitignore_parser.py
@@ -2,11 +2,11 @@ import collections
 import os
 import re
 
-from os.path import dirname, abspath
+from os.path import dirname
 from pathlib import Path
 
 def handle_negation(file_path, rules):
-    	matched = False
+	matched = False
 	for rule in rules:
 		if rule.match(file_path):
 			if rule.negation:
@@ -24,7 +24,7 @@ def parse_gitignore(full_path, base_dir=None):
 		for line in ignore_file:
 			counter += 1
 			line = line.rstrip('\n')
-			rule = rule_from_pattern(line, base_path=abspath(base_dir),
+			rule = rule_from_pattern(line, base_path=Path(base_dir).resolve(),
 									 source=(full_path, counter))
 			if rule:
 				rules.append(rule)
@@ -44,7 +44,7 @@ def rule_from_pattern(pattern, base_path=None, source=None):
 	Because git allows for nested .gitignore files, a base_path value
 	is required for correct behavior. The base path should be absolute.
 	"""
-	if base_path and base_path != abspath(base_path):
+	if base_path and base_path != Path(base_path).resolve():
 		raise ValueError('base_path must be absolute')
 	# Store the exact pattern for our repr and string functions
 	orig_pattern = pattern
@@ -120,7 +120,7 @@ class IgnoreRule(collections.namedtuple('IgnoreRule_', IGNORE_RULE_FIELDS)):
 	def match(self, abs_path):
 		matched = False
 		if self.base_path:
-			rel_path = str(Path(abs_path).relative_to(self.base_path))
+			rel_path = str(Path(abs_path).resolve().relative_to(self.base_path))
 		else:
 			rel_path = str(Path(abs_path))
 		if rel_path.startswith('./'):

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,6 @@
 from gitignore_parser import parse_gitignore
 from tempfile import NamedTemporaryFile
+import os
 from unittest import TestCase
 
 class Test(TestCase):
@@ -27,7 +28,12 @@ class Test(TestCase):
 		self.assertTrue(matches('/home/michael/waste.ignore'))
 
 def _parse_gitignore_string(s, fake_base_dir=None):
-	with NamedTemporaryFile('w') as tmp:
-		tmp.write(s)
-		tmp.seek(0)
-		return parse_gitignore(tmp.name, fake_base_dir)
+	# The file returned by NamedTemporaryFile cannot be opened twice on Windows
+	# without closing it first. Create it, close it, then open it again.
+	# Manually delete when we're done.
+	tmp = NamedTemporaryFile('w', delete=False)
+	tmp.write(s)
+	tmp.close()
+	success = parse_gitignore(tmp.name, fake_base_dir)
+	os.unlink(tmp.name)
+	return success

--- a/tests.py
+++ b/tests.py
@@ -14,6 +14,18 @@ class Test(TestCase):
 		self.assertTrue(matches('/home/michael/dir/main.pyc'))
 		self.assertTrue(matches('/home/michael/__pycache__'))
 
+	def test_negation(self):
+		matches = _parse_gitignore_string(
+			'''
+*.ignore
+!keep.ignore
+			''',
+			fake_base_dir='/home/michael'
+		)
+		self.assertTrue(matches('/home/michael/trash.ignore'))
+		self.assertFalse(matches('/home/michael/keep.ignore'))
+		self.assertTrue(matches('/home/michael/waste.ignore'))
+
 def _parse_gitignore_string(s, fake_base_dir=None):
 	with NamedTemporaryFile('w') as tmp:
 		tmp.write(s)


### PR DESCRIPTION
In this commit, I fixed two things: negation rules and trying to parse
"**" when the pattern has only one "*".

To make negation rules work, I had to add a completely separate method
for rule evaluation. You can't use Python any() to evaluate rules since
later rules override earlier rules. Instead, I had to go through the
rules one by one and have later rules (if they are negation rules)
override earlier matches. There's a handle_negation() method that does
this.

I also changed the pattern parsing to check for two characters before it
tries to evaluate "**". It seems to fix the bare "*" rule, but more
testing is needed.

Fixes: https://github.com/mherrmann/gitignore_parser/issues/12