### PR TITLE
Adding .editorconfig to preserve current whitespace styling. 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# Not the top-most EditorConfig file, only contains settings for this project.
+root = false
+
+# Unix-style newlines for all files
+[*]
+end_of_line = lf
+
+# Set default charset
+[*.{py,md,cfg,yml,gitignore}]
+charset = utf-8
+
+# Style for Python
+[*.py]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+
+# Style for YAML
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+insert_final_newline = true


### PR DESCRIPTION
Hello,

 looking at your plea for minimal Pull Requests, I decided to add a PR for a [EditorConfig](https://editorconfig.org/) first before considering other Pull Requests. 
In short: the `.editorconfig` will enforce whitespace styling for this project in a multitude of editors/IDEs, inlcuding the Github online editor natively and vscode and vim via plugins. You can check out https://editorconfig.org/ for all details. 
As you indicated that there were previous pull requests - in this project or another - that had issues with styling changes, this should alleviate some of those pains in the future. 
The PR is also atomic/non-invasive: no code is changed, so there is also no need for a new release.

I know this PR may sound like an advertisement for .editorconfig, but I am in no way affiliated with that project. I am only a (happy) user. The inclusion of the file should only have positive impact, if any. 
Feel free to edit the config file further to the project's preferences. 

```ini
# EditorConfig is awesome: https://EditorConfig.org

# Not the top-most EditorConfig file, only contains settings for this project.
root = false

# Unix-style newlines for all files
[*]
end_of_line = lf

# Set default charset
[*.{py,md,cfg,yml,gitignore}]
charset = utf-8

# Style for Python
[*.py]
indent_style = space
indent_size = 4
insert_final_newline = true

# Style for YAML
[*.{yml,yaml}]
indent_style = space
indent_size = 2
insert_final_newline = true
```