### PR TITLE
Support for directory-only negation

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -105,6 +105,22 @@ class Test(TestCase):
         self.assertTrue(matches('/home/michael/foo/world/Bar'))
         self.assertTrue(matches('/home/michael/foo/Bar'))
 
+    def test_directory_only_negation(self):
+        matches = _parse_gitignore_string('''
+data/**
+!data/**/
+!.gitkeep
+!data/01_raw/*
+            ''',
+            fake_base_dir='/home/michael'
+        )
+        self.assertFalse(matches('/home/michael/data/01_raw/'))
+        self.assertFalse(matches('/home/michael/data/01_raw/.gitkeep'))
+        self.assertFalse(matches('/home/michael/data/01_raw/raw_file.csv'))
+        self.assertFalse(matches('/home/michael/data/02_processed/'))
+        self.assertFalse(matches('/home/michael/data/02_processed/.gitkeep'))
+        self.assertTrue(matches('/home/michael/data/02_processed/processed_file.csv'))
+
     def test_single_asterisk(self):
         matches = _parse_gitignore_string('*', fake_base_dir='/home/michael')
         self.assertTrue(matches('/home/michael/file.txt'))


### PR DESCRIPTION
While integrating your library I found one case that is a mismatch with how `.gitignore` works. It relates to support of directory-only negation - useful thing when you want to discard some spool dir, but keep the directory structure in the version control. The feature is used by Kedro framework [in their proejct template](https://github.com/kedro-org/kedro/blob/main/kedro/templates/project/%7B%7B%20cookiecutter.repo_name%20%7D%7D/.gitignore#L13):

```
# ignore everything in the following folders
data/**
# except their sub-folders
!data/**/
# also keep all .gitkeep files
!.gitkeep
```

and makes it easy to store the structure of `data/` subdirs in git:

```
$ tree -a data/
data/
├── 01_raw
│   └── .gitkeep
├── 02_intermediate
│   └── .gitkeep
├── 03_primary
│   └── .gitkeep
├── 04_features
│   └── .gitkeep
├── 05_model_input
│   └── .gitkeep
├── 06_models
│   └── .gitkeep
└── 08_reporting
    └── .gitkeep

7 directories, 7 files
```

This PR fixes the directory-only-negation support, together with a small test. You can also verify the behaviour with pure git:

```
$ cat > .gitignore <<EOF
> data/**
> !data/**/
> !.gitkeep
> !data/01_raw/*
> EOF
$ git init
$ mkdir -p data/01_raw/
$ touch data/01_raw/.gitkeep
$ touch data/01_raw/data.csv
$ mkdir -p data/02_processed/
$ touch data/02_processed/.gitkeep
$ touch data/02_processed/data.csv
$ git add -A
$ git status
On branch master

No commits yet

Changes to be committed:
  (use "git rm --cached <file>..." to unstage)
	new file:   .gitignore
	new file:   data/01_raw/.gitkeep
	new file:   data/01_raw/data.csv
	new file:   data/02_processed/.gitkeep
```

If you're OK with my modifications, I would be glad if you can release it as a new version of pypi, so I can  integrate non-fork version in my project. Thanks :-)