### PR TITLE
Ensure that `Path` type is supported in `matches()`

### DIFF
--- a/gitignore_parser.py
+++ b/gitignore_parser.py
@@ -4,6 +4,7 @@ import re
 
 from os.path import dirname
 from pathlib import Path
+from typing import Union
 
 def handle_negation(file_path, rules):
     matched = False
@@ -132,7 +133,7 @@ class IgnoreRule(collections.namedtuple('IgnoreRule_', IGNORE_RULE_FIELDS)):
     def __repr__(self):
         return ''.join(['IgnoreRule(\'', self.pattern, '\')'])
 
-    def match(self, abs_path):
+    def match(self, abs_path: Union[str, Path]):
         matched = False
         if self.base_path:
             rel_path = str(Path(abs_path).resolve().relative_to(self.base_path))
@@ -140,7 +141,7 @@ class IgnoreRule(collections.namedtuple('IgnoreRule_', IGNORE_RULE_FIELDS)):
             rel_path = str(Path(abs_path))
         # Path() strips the trailing slash, so we need to preserve it
         # in case of directory-only negation
-        if self.negation and abs_path[-1] == '/':
+        if self.negation and type(abs_path) == str and abs_path[-1] == '/':
             rel_path += '/'
         if rel_path.startswith('./'):
             rel_path = rel_path[2:]

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch, mock_open
+from pathlib import Path
 
 from gitignore_parser import parse_gitignore
 
@@ -127,6 +128,10 @@ data/**
         self.assertTrue(matches('/home/michael/directory'))
         self.assertTrue(matches('/home/michael/directory-trailing/'))
 
+    def test_supports_path_type_argument(self):
+        matches = _parse_gitignore_string('file1\n!file2', fake_base_dir='/home/michael')
+        self.assertTrue(matches(Path('/home/michael/file1')))
+        self.assertFalse(matches(Path('/home/michael/file2')))
 
 def _parse_gitignore_string(data: str, fake_base_dir: str = None):
     with patch('builtins.open', mock_open(read_data=data)):


### PR DESCRIPTION
Fixes #37 