### PR TITLE
Fix directory rule matching similar files

### DIFF
--- a/gitignore_parser.py
+++ b/gitignore_parser.py
@@ -212,6 +212,8 @@ def fnmatch_pathname_to_regex(
     res.insert(0, '(?ms)')
     if not directory_only:
         res.append('$')
-    if directory_only and negation:
+    elif directory_only and negation:
         res.append('/$')
+    else:
+        res.append('($|\/)')
     return ''.join(res)

--- a/tests.py
+++ b/tests.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from gitignore_parser import parse_gitignore
 
-from unittest import TestCase
+from unittest import TestCase, main
 
 
 class Test(TestCase):
@@ -80,6 +80,7 @@ class Test(TestCase):
         self.assertTrue(matches('/home/michael/.venv'))
         self.assertTrue(matches('/home/michael/.venv/folder'))
         self.assertTrue(matches('/home/michael/.venv/file.txt'))
+        self.assertFalse(matches('/home/michael/.venv_no_folder'))
 
     def test_ignore_directory_asterisk(self):
         matches = _parse_gitignore_string('.venv/*', fake_base_dir='/home/michael')
@@ -137,3 +138,6 @@ def _parse_gitignore_string(data: str, fake_base_dir: str = None):
     with patch('builtins.open', mock_open(read_data=data)):
         success = parse_gitignore(f'{fake_base_dir}/.gitignore', fake_base_dir)
         return success
+
+if __name__ == '__main__':
+    main()

--- a/tests.py
+++ b/tests.py
@@ -80,7 +80,8 @@ class Test(TestCase):
         self.assertTrue(matches('/home/michael/.venv'))
         self.assertTrue(matches('/home/michael/.venv/folder'))
         self.assertTrue(matches('/home/michael/.venv/file.txt'))
-        self.assertFalse(matches('/home/michael/.venv_no_folder'))
+        self.assertFalse(matches('/home/michael/.venv_other_folder'))
+        self.assertFalse(matches('/home/michael/.venv_no_folder.py'))
 
     def test_ignore_directory_asterisk(self):
         matches = _parse_gitignore_string('.venv/*', fake_base_dir='/home/michael')


### PR DESCRIPTION
Fixes https://github.com/mherrmann/gitignore_parser/issues/45

Added a test to show the issue that's fixed by this PR.
e.g.
If there is a rule:
```
.venv/
```
Then also files called `.venv_file.py` or `.venv_other_directory` are matched.