### PR TITLE
perf: optimize `handle_negation` to check rules in reversed order

### DIFF
--- a/gitignore_parser.py
+++ b/gitignore_parser.py
@@ -4,17 +4,13 @@ import re
 
 from os.path import dirname
 from pathlib import Path
-from typing import Union
+from typing import Reversible, Union
 
-def handle_negation(file_path, rules):
-    matched = False
-    for rule in rules:
+def handle_negation(file_path, rules: Reversible["IgnoreRule"]):
+    for rule in reversed(rules):
         if rule.match(file_path):
-            if rule.negation:
-                matched = False
-            else:
-                matched = True
-    return matched
+            return not rule.negation
+    return False
 
 def parse_gitignore(full_path, base_dir=None):
     if base_dir is None:


### PR DESCRIPTION
The utility function `handle_negation` can be optimized to return early if we iterate over `rules` in reversed order.

In the previous implementation, `handle_negation` always iterates over all `rules` to find for matches. However, since later rules take precedence, we can perform the search in reversed order and return early.

This pull request is a performance improvement and should not change behavior, as verified by the tests.