### PR TITLE
ci: fix CI step names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Test with pytest
+    - name: Run tests
       run: |
         python -m unittest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: ['3.11', '3.10', '3.9', '3.8', '3.7']
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
Fix the name of the CI steps of the `test` job.

The setup step was previously named "Set up Python 3.8", which is misleading since we have a matrix of Python versions to test with. The new name now uses the correct Python version.

The test step previously mentioned `pytest`, which is wrong since we currently use unittest for testing. I chose simply "Run tests" to avoid mentioning any particular testing framework.