### PR TITLE
chore: list Python versions 3.8 to 3.11 in the classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,16 +21,20 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
-    
+
         'License :: OSI Approved :: MIT License',
-    
+
         'Operating System :: OS Independent',
-    
+
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
 
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules'


### PR DESCRIPTION
Extend the list of supported Python versions up to 3.11 in the `classifiers` in `setup.py`. This shows users that we support Python 3.11, as attested by the CI checks.