### PR TITLE
refactor: remove regex flags

### DIFF
--- a/gitignore_parser.py
+++ b/gitignore_parser.py
@@ -205,7 +205,6 @@ def fnmatch_pathname_to_regex(
             res.append(re.escape(c))
     if anchored:
         res.insert(0, '^')
-    res.insert(0, '(?ms)')
     if not directory_only:
         res.append('$')
     elif directory_only and negation:


### PR DESCRIPTION
According to [the official Python docs](https://docs.python.org/3.5/library/re.html#regular-expression-syntax), the regex flags `'m'` and `'s'` correspond to [`re.M`](https://docs.python.org/3.5/library/re.html#re.M) and [`re.S`](https://docs.python.org/3.5/library/re.html#re.S), which only matter when dealing with newlines or multiline strings. Since each ignore rule is a single-line pattern, we can safely remove those flags without any change in behavior.

This might be sufficient for https://github.com/mherrmann/gitignore_parser/pull/11 to work correctly, although I haven't tested it.