### PR TITLE
refactor: clean up unused variable

### DIFF
--- a/gitignore_parser.py
+++ b/gitignore_parser.py
@@ -112,7 +112,6 @@ def rule_from_pattern(pattern, base_path=None, source=None):
         source=source
     )
 
-whitespace_re = re.compile(r'(\\ )+$')
 
 IGNORE_RULE_FIELDS = [
     'pattern', 'regex',  # Basic values


### PR DESCRIPTION
Remove the variable `whitespace_re`, which is not used anywhere in the codebase.