### PR TITLE
Fix patterns with leading exclamation marks

### DIFF
--- a/gitignore_parser.py
+++ b/gitignore_parser.py
@@ -84,8 +84,9 @@ def rule_from_pattern(pattern, base_path=None, source=None):
         pattern = pattern[1:]
     if pattern[-1] == '/':
         pattern = pattern[:-1]
-    # patterns with leading hashes are escaped with a backslash in front, unescape it
-    if pattern[0] == '\\' and pattern[1] == '#':
+    # patterns with leading hashes or exclamation marks are escaped with a
+    # backslash in front, unescape it
+    if pattern[0] == '\\' and pattern[1] in ('#', '!'):
         pattern = pattern[1:]
     # trailing spaces are ignored unless they are escaped with a backslash
     i = len(pattern)-1

--- a/tests.py
+++ b/tests.py
@@ -101,6 +101,11 @@ class Test(TestCase):
         self.assertFalse(matches('/home/michael/keep.ignore'))
         self.assertTrue(matches('/home/michael/waste.ignore'))
 
+    def test_literal_exclamation_mark(self):
+        matches = _parse_gitignore_string('\\!ignore_me!', fake_base_dir='/home/michael')
+        self.assertTrue(matches('/home/michael/!ignore_me!'))
+        self.assertFalse(matches('/home/michael/ignore_me!'))
+        self.assertFalse(matches('/home/michael/ignore_me'))
 
     def test_double_asterisks(self):
         matches = _parse_gitignore_string('foo/**/Bar', fake_base_dir='/home/michael')


### PR DESCRIPTION
Quoting the relevant paragraph in
https://git-scm.com/docs/gitignore#_pattern_format:

>  Put a backslash ("`\`") in front of the first "`!`" for patterns that
>  begin with a literal "`!`", for example, "`\!important!.txt`".
