### PR TITLE
Fix "a/**/b" matching "a/bb"

### DIFF
--- a/gitignore_parser.py
+++ b/gitignore_parser.py
@@ -171,10 +171,11 @@ def fnmatch_pathname_to_regex(
             try:
                 if pattern[i] == '*':
                     i += 1
-                    res.append('.*')
-                    if pattern[i] == '/':
+                    if i < n and pattern[i] == '/':
                         i += 1
-                        res.append(''.join([seps_group, '?']))
+                        res.append(''.join(['(.*', seps_group, ')?']))
+                    else:
+                        res.append('.*')
                 else:
                     res.append(''.join([nonsep, '*']))
             except IndexError:

--- a/tests.py
+++ b/tests.py
@@ -112,6 +112,7 @@ class Test(TestCase):
         self.assertTrue(matches('/home/michael/foo/hello/Bar'))
         self.assertTrue(matches('/home/michael/foo/world/Bar'))
         self.assertTrue(matches('/home/michael/foo/Bar'))
+        self.assertFalse(matches('/home/michael/foo/BarBar'))
 
     def test_directory_only_negation(self):
         matches = _parse_gitignore_string('''


### PR DESCRIPTION
Quoting https://git-scm.com/docs/gitignore#_pattern_format:

  A slash followed by two consecutive asterisks then a slash matches
  zero or more directories. For example, "`a/**/b`" matches "`a/b`",
  "`a/x/b`", "`a/x/y/b`" and so on.

I read this to mean that the "`/**/`" pattern should only match at
directory boundaries, i.e. it is NOT meant to be equivalent to "`/**`".

Fix this by making the last '`/`' mandatory when the preceding "`.*`"
regex match is non-empty.

In other words, for "`/**/`" patterns, change the resulting regex from
  `[/].*[/]?`
to
  `[/](.*[/])?`
