### PR TITLE
Fix multi-asterisks that fall outside of the special cases

### DIFF
--- a/gitignore_parser.py
+++ b/gitignore_parser.py
@@ -58,14 +58,10 @@ def rule_from_pattern(pattern, base_path=None, source=None):
         pattern = pattern[1:]
     else:
         negation = False
-    # Discard anything with invalid double-asterisks -- they can appear
-    # at the start or the end, or be surrounded by slashes
-    for m in re.finditer(r'\*\*', pattern):
-        start_index = m.start()
-        if (start_index != 0 and start_index != len(pattern) - 2 and
-                (pattern[start_index - 1] != '/' or
-                 pattern[start_index + 2] != '/')):
-            return
+    # Double-asterisks not surrounded by slashes (or at the start/end) should
+    # be treated like single-asterisks
+    pattern = re.sub(r'([^/])\*\*', r'\1*', pattern)
+    pattern = re.sub(r'\*\*([^/])', r'*\1', pattern)
 
     # Special-casing '/', which doesn't match any files or directories
     if pattern.rstrip() == '/':

--- a/gitignore_parser.py
+++ b/gitignore_parser.py
@@ -49,19 +49,16 @@ def rule_from_pattern(pattern, base_path=None, source=None):
     # Discard comments and separators
     if pattern.strip() == '' or pattern[0] == '#':
         return
-    # Discard anything with more than two consecutive asterisks
-    if pattern.find('***') > -1:
-        return
     # Strip leading bang before examining double asterisks
     if pattern[0] == '!':
         negation = True
         pattern = pattern[1:]
     else:
         negation = False
-    # Double-asterisks not surrounded by slashes (or at the start/end) should
-    # be treated like single-asterisks
-    pattern = re.sub(r'([^/])\*\*', r'\1*', pattern)
-    pattern = re.sub(r'\*\*([^/])', r'*\1', pattern)
+    # Multi-asterisks not surrounded by slashes (or at the start/end) should
+    # be treated like single-asterisks.
+    pattern = re.sub(r'([^/])\*{2,}', r'\1*', pattern)
+    pattern = re.sub(r'\*{2,}([^/])', r'*\1', pattern)
 
     # Special-casing '/', which doesn't match any files or directories
     if pattern.rstrip() == '/':

--- a/tests.py
+++ b/tests.py
@@ -124,6 +124,14 @@ class Test(TestCase):
         self.assertFalse(matches('/home/michael/a/bb/cc/d'))
         self.assertFalse(matches('/home/michael/a/bb/XX/cc/d'))
 
+    def test_more_asterisks_handled_like_single_asterisk(self):
+        matches = _parse_gitignore_string('***a/b', fake_base_dir='/home/michael')
+        self.assertTrue(matches('/home/michael/XYZa/b'))
+        self.assertFalse(matches('/home/michael/foo/a/b'))
+        matches = _parse_gitignore_string('a/b***', fake_base_dir='/home/michael')
+        self.assertTrue(matches('/home/michael/a/bXYZ'))
+        self.assertFalse(matches('/home/michael/a/b/foo'))
+
     def test_directory_only_negation(self):
         matches = _parse_gitignore_string('''
 data/**

--- a/tests.py
+++ b/tests.py
@@ -113,6 +113,17 @@ class Test(TestCase):
         self.assertTrue(matches('/home/michael/foo/world/Bar'))
         self.assertTrue(matches('/home/michael/foo/Bar'))
 
+    def test_double_asterisk_without_slashes_handled_like_single_asterisk(self):
+        matches = _parse_gitignore_string('a/b**c/d', fake_base_dir='/home/michael')
+        self.assertTrue(matches('/home/michael/a/bc/d'))
+        self.assertTrue(matches('/home/michael/a/bXc/d'))
+        self.assertTrue(matches('/home/michael/a/bbc/d'))
+        self.assertTrue(matches('/home/michael/a/bcc/d'))
+        self.assertFalse(matches('/home/michael/a/bcd'))
+        self.assertFalse(matches('/home/michael/a/b/c/d'))
+        self.assertFalse(matches('/home/michael/a/bb/cc/d'))
+        self.assertFalse(matches('/home/michael/a/bb/XX/cc/d'))
+
     def test_directory_only_negation(self):
         matches = _parse_gitignore_string('''
 data/**


### PR DESCRIPTION
Commits
- Fix handling of `**` where it's supposed to be treated like `*`
- Fix handling of `***`, i.e. to be treated like `*`
