### PR TITLE
Fix lack of implicit anchoring of patterns to directory separators

### DIFF
--- a/gitignore_parser.py
+++ b/gitignore_parser.py
@@ -205,6 +205,8 @@ def fnmatch_pathname_to_regex(
             res.append(re.escape(c))
     if anchored:
         res.insert(0, '^')
+    else:
+        res.insert(0, f"(^|{seps_group})")
     if not directory_only:
         res.append('$')
     elif directory_only and negation:

--- a/gitignore_parser.py
+++ b/gitignore_parser.py
@@ -210,5 +210,5 @@ def fnmatch_pathname_to_regex(
     elif directory_only and negation:
         res.append('/$')
     else:
-        res.append('($|\/)')
+        res.append('($|\\/)')
     return ''.join(res)

--- a/tests.py
+++ b/tests.py
@@ -18,6 +18,15 @@ class Test(TestCase):
         self.assertTrue(matches('/home/michael/dir/main.pyc'))
         self.assertTrue(matches('/home/michael/__pycache__'))
 
+    def test_incomplete_filename(self):
+        matches = _parse_gitignore_string('o.py', fake_base_dir='/home/michael')
+        self.assertTrue(matches('/home/michael/o.py'))
+        self.assertFalse(matches('/home/michael/foo.py'))
+        self.assertFalse(matches('/home/michael/o.pyc'))
+        self.assertTrue(matches('/home/michael/dir/o.py'))
+        self.assertFalse(matches('/home/michael/dir/foo.py'))
+        self.assertFalse(matches('/home/michael/dir/o.pyc'))
+
     def test_wildcard(self):
         matches = _parse_gitignore_string(
             'hello.*',


### PR DESCRIPTION
This proposes a different fix to issue #10 than what is currently in
PR #11. Not sure which solution is more correct/preferable.

Commits:
- Fix `DeprecationWarning: invalid escape sequence '\/'`
- Fix lack of implicit anchoring of patterns to directory separators
