### PR TITLE
Add Windows CI Runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.11', '3.10', '3.9', '3.8', '3.7']
+        python-version: ['3.12', '3.11', '3.10', '3.9', '3.8', '3.7']
         os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: ['3.11', '3.10', '3.9', '3.8', '3.7']
+        os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/tests.py
+++ b/tests.py
@@ -4,7 +4,7 @@ from tempfile import TemporaryDirectory
 
 from gitignore_parser import parse_gitignore
 
-from unittest import TestCase, main
+from unittest import TestCase, main, SkipTest
 
 
 class Test(TestCase):
@@ -195,8 +195,12 @@ data/**
             # Create a symlink to another directory.
             link = project_dir / 'link'
             target = another_dir / 'target'
-            link.symlink_to(target)
-
+            
+            try:
+                link.symlink_to(target)
+            except OSError:
+                e = "Current User does not have permissions to perform symlink/"
+                raise SkipTest(e)
             # Check the intended behavior according to
             # https://git-scm.com/docs/gitignore#_notes:
             # Symbolic links are not followed and are matched as if they were regular

--- a/tests.py
+++ b/tests.py
@@ -188,11 +188,13 @@ data/**
         This test ensures that the issue is now fixed.
         """
         with TemporaryDirectory() as project_dir, TemporaryDirectory() as another_dir:
+            project_dir = Path(project_dir).resolve()
+            another_dir = Path(another_dir).resolve()
             matches = _parse_gitignore_string('link', fake_base_dir=project_dir)
 
             # Create a symlink to another directory.
-            link = Path(project_dir, 'link')
-            target = Path(another_dir, 'target')
+            link = project_dir / 'link'
+            target = another_dir / 'target'
             link.symlink_to(target)
 
             # Check the intended behavior according to

--- a/tests.py
+++ b/tests.py
@@ -199,7 +199,7 @@ data/**
             try:
                 link.symlink_to(target)
             except OSError:
-                e = "Current User does not have permissions to perform symlink/"
+                e = "Current user does not have permissions to perform symlink."
                 raise SkipTest(e)
             # Check the intended behavior according to
             # https://git-scm.com/docs/gitignore#_notes:


### PR DESCRIPTION
With recent changes to start using `Path`, gitignore_parser lost some support for Windows which was not caught due to CI not running on a windows runner.  Also, I added python 3.12 testing

## Issues with using `Path` which broke windows support:

1. `Path` strips some trailing characters. Currently caught are `' '` and `'.'`
2. `Path` switches path separators to the current os's path separator, breaking the regex is some instances.

## Broken CI when turning on Windows Runners, before applying fixes:

1. test_ignore_directory, specifically `/home/michael/.venv/folder` as `Path` turns it into `.venv\\folder` and current regex fails
2. test_trailingspaces, as all the spaces are stripped on windows
3. test_wildcard, specifically `/home/michael/hello.` as `Path` strips the '.' on Windows

## Other Miscellaneous issue:

test_symlink_to_another_directory failed on windows - but was a test issue, not an issue with the gitignore_parser.  The issue is that TemproaryDirectory() itself uses a symlink on windows, so the base_dir does not match due to the fact that in one instance its the symlink and the other is the full path. I just resolve the symlink on the `project_dir` and `another_dir`, and focus on the symlink resolution the test truly cares about.

I also added logic to automatically skip the test if the symlink fails. This happens locally if not running as an admin as you don't have permission to create symlinks.

## This PR fixes the following:

1. preserve symbols that are stripped by path: ' ' and '.'
2. Convert `rel_path` to posix form with `as_posix()` rather than to the current OS's form with `str`

Closes #60 