### PR TITLE
Add support and testing for Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.10', '3.9', '3.8', '3.7']
+        python-version: ['3.12', '3.11', '3.10', '3.9', '3.8', '3.7']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
 
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules'


### PR DESCRIPTION
Python 3.12 was released not too long ago and it would be nice to keep this library current.

This change updates the distributions classifier to include Python 3.12 as being supported. It also adds 3.12 to the CI's testing matrix to test it as well.