### PR TITLE
ValueError raised on symlinks that point to a different path (fix #29)

### DIFF
--- a/gitignore_parser.py
+++ b/gitignore_parser.py
@@ -21,7 +21,7 @@ def parse_gitignore(full_path, base_dir=None):
         for line in ignore_file:
             counter += 1
             line = line.rstrip('\n')
-            rule = rule_from_pattern(line, base_path=Path(base_dir).resolve(),
+            rule = rule_from_pattern(line, base_path=_normalize_path(base_dir),
                                      source=(full_path, counter))
             if rule:
                 rules.append(rule)
@@ -41,8 +41,6 @@ def rule_from_pattern(pattern, base_path=None, source=None):
     Because git allows for nested .gitignore files, a base_path value
     is required for correct behavior. The base path should be absolute.
     """
-    if base_path and base_path != Path(base_path).resolve():
-        raise ValueError('base_path must be absolute')
     # Store the exact pattern for our repr and string functions
     orig_pattern = pattern
     # Early returns follow

--- a/tests.py
+++ b/tests.py
@@ -201,6 +201,21 @@ data/**
             # files.
             self.assertTrue(matches(link))
 
+    def test_symlink_to_symlink_directory(self):
+        with (TemporaryDirectory() as project_dir,
+                TemporaryDirectory() as link_dir):
+            # create a link to project dir
+            link = Path(link_dir, 'link')
+            link.symlink_to(project_dir)
+            # consider a file using the link path
+            file = Path(link, 'file.txt')
+            # pass the link as the base directory
+            matches = _parse_gitignore_string(
+                'file.txt', fake_base_dir=str(link))
+            # check symbolic link is not resolved for both base path AND file
+            self.assertTrue(matches(file))
+
+
 def _parse_gitignore_string(data: str, fake_base_dir: str = None):
     with patch('builtins.open', mock_open(read_data=data)):
         success = parse_gitignore(f'{fake_base_dir}/.gitignore', fake_base_dir)


### PR DESCRIPTION
Fix https://github.com/metwork-framework/circus_autorestart_plugin/issues/6
Completing fix of https://github.com/mherrmann/gitignore_parser/issues/29 (v0.1.9 causing a regression in our metwork-framework application)
=> If the goal is to not solve symlink, **all** the symlinks must not be solved, including base_dir/base_path.